### PR TITLE
[e2e test only] :seedling: (chore): Bump sigs.k8s.io/cluster-api-provider-vsphere/test

### DIFF
--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -15,7 +15,7 @@ require (
 	k8s.io/client-go v0.31.1
 	k8s.io/klog/v2 v2.130.1
 	sigs.k8s.io/cluster-api v1.8.3
-	sigs.k8s.io/cluster-api-provider-vsphere/test v1.11.0
+	sigs.k8s.io/cluster-api-provider-vsphere/test v1.11.1
 	sigs.k8s.io/cluster-api/test v1.8.3
 	sigs.k8s.io/controller-runtime v0.19.0
 )

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -414,8 +414,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 h1:2770sDpzrjjsA
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/cluster-api v1.8.3 h1:N6i25rF5QMadwVg2UPfuO6CzmNXjqnF2r1MAO+kcsro=
 sigs.k8s.io/cluster-api v1.8.3/go.mod h1:pXv5LqLxuIbhGIXykyNKiJh+KrLweSBajVHHitPLyoY=
-sigs.k8s.io/cluster-api-provider-vsphere/test v1.11.0 h1:h95Xcu+mVXQhJ6u3MW9LO0zHxvYZoDAgkSCSn2ku6Tc=
-sigs.k8s.io/cluster-api-provider-vsphere/test v1.11.0/go.mod h1:tcpOgmcVSHtcMtXMVlxHjHaCQ6DbtH350/zGugtAjVY=
+sigs.k8s.io/cluster-api-provider-vsphere/test v1.11.1 h1:0yoXeineahPorBUFBnm560AgR/6Vh+lxnR2IYMw/MXo=
+sigs.k8s.io/cluster-api-provider-vsphere/test v1.11.1/go.mod h1:LwhIfqi6pgkxwN/rqRPnJIAMFe1xPODFZymQQppMBV0=
 sigs.k8s.io/cluster-api/test v1.8.3 h1:kOGXedULJnZIcl7xHt/Kkaju5IRqkd12H6QSLAqX8LE=
 sigs.k8s.io/cluster-api/test v1.8.3/go.mod h1:odnzMkDndCRPCWdwl0CRofyZyY857wN34bUih1MLKIc=
 sigs.k8s.io/controller-runtime v0.19.0 h1:nWVM7aq+Il2ABxwiCizrVDSlmDcshi9llbaFbC0ji/Q=


### PR DESCRIPTION
Bumps the sigs-k8s group in /test/e2e with 1 update: [sigs.k8s.io/cluster-api-provider-vsphere/test](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere).


Updates `sigs.k8s.io/cluster-api-provider-vsphere/test` from 1.11.0 to 1.11.1
- [Release notes](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases)
- [Commits](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/compare/v1.11.0...v1.11.1)

---
updated-dependencies:
- dependency-name: sigs.k8s.io/cluster-api-provider-vsphere/test dependency-type: direct:production update-type: version-update:semver-patch dependency-group: sigs-k8s ...

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
