### PR TITLE
Fix the stale Node issue in cache

### DIFF
--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,7 +1,8 @@
 module tools
 
-go 1.22
-toolchain go1.22.5
+go 1.22.0
+
+toolchain go1.23.3
 
 require (
 	github.com/onsi/ginkgo/v2 v2.21.0


### PR DESCRIPTION
The Node object in the nodeMap is never updated after added. After the Node gets its IP address , Node.status.addresses is still empty. The route controller report this error during creating the static route:

node xxxx has neither InternalIP nor ExternalIP

We should always get Node from the informer cache because it 's up-to-date

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
