### PR TITLE
Add support for service annotation propagation

### DIFF
--- a/pkg/cloudprovider/vsphereparavirtual/cloud.go
+++ b/pkg/cloudprovider/vsphereparavirtual/cloud.go
@@ -62,6 +62,9 @@ var (
 
 	// podIPPoolType specifies if Pod IP addresses are public or private.
 	podIPPoolType string
+
+	// serviceAnnotationPropagationEnabled if set to true, will propagate the service annotation to resource in supervisor cluster.
+	serviceAnnotationPropagationEnabled bool
 )
 
 func init() {
@@ -89,6 +92,7 @@ func init() {
 	flag.BoolVar(&vmservice.IsLegacy, "is-legacy-paravirtual", false, "If true, machine label selector will start with capw.vmware.com. By default, it's false, machine label selector will start with capv.vmware.com.")
 	flag.BoolVar(&vpcModeEnabled, "enable-vpc-mode", false, "If true, routable pod controller will start with VPC mode. It is useful only when route controller is enabled in vsphereparavirtual mode")
 	flag.StringVar(&podIPPoolType, "pod-ip-pool-type", "", "Specify if Pod IP address is Public or Private routable in VPC network. Valid values are Public and Private")
+	flag.BoolVar(&serviceAnnotationPropagationEnabled, "enable-service-annotation-propagation", false, "If true, will propagate the service annotation to resource in supervisor cluster.")
 }
 
 // Creates new Controller node interface and returns
@@ -139,7 +143,7 @@ func (cp *VSphereParavirtual) Initialize(clientBuilder cloudprovider.ControllerC
 	}
 	cp.routes = routes
 
-	lb, err := NewLoadBalancer(clusterNS, kcfg, cp.ownerReference)
+	lb, err := NewLoadBalancer(clusterNS, kcfg, cp.ownerReference, serviceAnnotationPropagationEnabled)
 	if err != nil {
 		klog.Errorf("Failed to init LoadBalancer: %v", err)
 	}

--- a/pkg/cloudprovider/vsphereparavirtual/loadbalancer.go
+++ b/pkg/cloudprovider/vsphereparavirtual/loadbalancer.go
@@ -39,7 +39,7 @@ type loadBalancer struct {
 }
 
 // NewLoadBalancer returns an implementation of cloudprovider.LoadBalancer
-func NewLoadBalancer(clusterNS string, kcfg *rest.Config, ownerRef *metav1.OwnerReference) (cloudprovider.LoadBalancer, error) {
+func NewLoadBalancer(clusterNS string, kcfg *rest.Config, ownerRef *metav1.OwnerReference, serviceAnnotationPropagationEnabled bool) (cloudprovider.LoadBalancer, error) {
 	klog.V(1).Info("Create load balancer for vsphere paravirtual cloud provider")
 
 	client, err := vmservice.GetVmopClient(kcfg)
@@ -47,7 +47,7 @@ func NewLoadBalancer(clusterNS string, kcfg *rest.Config, ownerRef *metav1.Owner
 		klog.Errorf("failed to create load balancer: %v", err)
 		return nil, err
 	}
-	vmService := vmservice.NewVMService(client, clusterNS, ownerRef)
+	vmService := vmservice.NewVMService(client, clusterNS, ownerRef, serviceAnnotationPropagationEnabled)
 	return &loadBalancer{
 		vmService: vmService,
 	}, nil

--- a/pkg/cloudprovider/vsphereparavirtual/loadbalancer_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/loadbalancer_test.go
@@ -60,26 +60,34 @@ func newTestLoadBalancer() (cloudprovider.LoadBalancer, *dynamicfake.FakeDynamic
 	fc := dynamicfake.NewSimpleDynamicClient(scheme)
 	fcw := vmopclient.NewFakeClientSet(fc)
 
-	vms := vmservice.NewVMService(fcw, testClusterNameSpace, &testOwnerReference)
+	vms := vmservice.NewVMService(fcw, testClusterNameSpace, &testOwnerReference, false)
 	return &loadBalancer{vmService: vms}, fc
 }
 
 func TestNewLoadBalancer(t *testing.T) {
 	testCases := []struct {
-		name   string
-		config *rest.Config
-		err    error
+		name                                string
+		config                              *rest.Config
+		serviceAnnotationPropagationEnabled bool
+		err                                 error
 	}{
 		{
-			name:   "NewLoadBalancer: when everything is ok",
-			config: &rest.Config{},
-			err:    nil,
+			name:                                "NewLoadBalancer: when serviceAnnotationPropagationEnabled is false",
+			config:                              &rest.Config{},
+			serviceAnnotationPropagationEnabled: false,
+			err:                                 nil,
+		},
+		{
+			name:                                "NewLoadBalancer: when serviceAnnotationPropagationEnabled is true",
+			config:                              &rest.Config{},
+			serviceAnnotationPropagationEnabled: true,
+			err:                                 nil,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			_, err := NewLoadBalancer(testClusterNameSpace, testCase.config, &testOwnerReference)
+			_, err := NewLoadBalancer(testClusterNameSpace, testCase.config, &testOwnerReference, testCase.serviceAnnotationPropagationEnabled)
 			assert.Equal(t, testCase.err, err)
 		})
 	}

--- a/pkg/cloudprovider/vsphereparavirtual/vmservice/types.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmservice/types.go
@@ -41,7 +41,8 @@ type VMService interface {
 
 // vmService takes care of mapping of LB type of service to VM service in supervisor cluster
 type vmService struct {
-	vmClient       vmop.Interface
-	namespace      string
-	ownerReference *metav1.OwnerReference
+	vmClient                            vmop.Interface
+	namespace                           string
+	ownerReference                      *metav1.OwnerReference
+	serviceAnnotationPropagationEnabled bool
 }


### PR DESCRIPTION
What this PR does / why we need it:
Enable propagation of Service annotations from workload clusters to influence final Service creation.
Only propagates annotations when enable-service-annotation-propagation is explicitly set true.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #

Special notes for your reviewer:
